### PR TITLE
fix: 404 Cannot find any route matching, when adding a child route.

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -66,8 +66,19 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
       if (node && node.placeholderChildren.length > 1) {
         // https://github.com/unjs/radix3/issues/95
         const remaining = sections.length - i;
+
+        const sortedPlaceholderChildren = [...node.placeholderChildren].sort(
+          (a, b) =>
+            a.maxDepth === remaining && b.maxDepth === remaining
+              ? 0
+              : a.maxDepth === remaining
+                ? -1
+                : b.maxDepth === remaining
+                  ? 1
+                  : b.maxDepth - a.maxDepth,
+        );
         node =
-          node.placeholderChildren.find((c) => c.maxDepth === remaining) ||
+          sortedPlaceholderChildren.find((c) => c.maxDepth >= remaining) ||
           null;
       } else {
         node = node.placeholderChildren[0] || null;

--- a/src/router.ts
+++ b/src/router.ts
@@ -66,19 +66,8 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
       if (node && node.placeholderChildren.length > 1) {
         // https://github.com/unjs/radix3/issues/95
         const remaining = sections.length - i;
-
-        const sortedPlaceholderChildren = [...node.placeholderChildren].sort(
-          (a, b) =>
-            a.maxDepth === remaining && b.maxDepth === remaining
-              ? 0
-              : (a.maxDepth === remaining
-                ? -1
-                : b.maxDepth === remaining
-                  ? 1
-                  : b.maxDepth - a.maxDepth),
-        );
         node =
-          sortedPlaceholderChildren.find((c) => c.maxDepth >= remaining) ||
+          node.placeholderChildren.find((c) => c.maxDepth === remaining) ||
           null;
       } else {
         node = node.placeholderChildren[0] || null;

--- a/src/router.ts
+++ b/src/router.ts
@@ -22,6 +22,7 @@ export function createRouter<T extends RadixNodeData = RadixNodeData>(
 
   if (options.routes) {
     for (const path in options.routes) {
+      console.log("insert", path);
       insert(ctx, normalizeTrailingSlash(path), options.routes[path]);
     }
   }
@@ -45,6 +46,7 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
   }
 
   const sections = path.split("/");
+  console.log("sections", sections);
 
   const params: MatchedRoute["params"] = {};
   let paramsFound = false;
@@ -54,6 +56,7 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
 
   for (let i = 0; i < sections.length; i++) {
     const section = sections[i];
+    console.log(i, "section", section, node);
 
     if (node.wildcardChildNode !== null) {
       wildcardNode = node.wildcardChildNode;
@@ -64,36 +67,37 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
     const nextNode = node.children.get(section);
     if (nextNode === undefined) {
       if (node && node.placeholderChildren.length > 1) {
+        console.log("node && node.placeholderChildren.length > 1");
         // https://github.com/unjs/radix3/issues/95
         const remaining = sections.length - i;
-
+        console.log("i", i, "remaining", remaining, "sections", sections);
+        console.log("node.placeholderChildren", node.placeholderChildren);
+        // prioritize items with the exact maxDepth as remaining
         const sortedPlaceholderChildren = [...node.placeholderChildren].sort(
           (a, b) => {
-            // If both items have maxDepth equal to remaining, no change in order
             if (a.maxDepth === remaining && b.maxDepth === remaining) {
               return 0;
             }
-            // If only item a has maxDepth equal to remaining, it should come before b
             else if (a.maxDepth === remaining) {
               return -1;
             }
-            // If only item b has maxDepth equal to remaining, it should come after a
             else if (b.maxDepth === remaining) {
               return 1;
             }
-            // If maxDepth is not equal to remaining for both items, sort based on their maxDepth
             else {
               return b.maxDepth - a.maxDepth;
             }
           },
         );
+
         node =
-          sortedPlaceholderChildren.find((c) => c.maxDepth >= remaining) ||
-          null;
+          sortedPlaceholderChildren.find((c) => c.maxDepth >= remaining) || null;
       } else {
+        console.log("here");
         node = node.placeholderChildren[0] || null;
       }
       if (!node) {
+        console.log("unfound node");
         break;
       }
       if (node.paramName) {
@@ -159,14 +163,30 @@ function insert(ctx: RadixRouterContext, path: string, data: any) {
         childNode.paramName = section.slice(3 /* "**:" */) || "_";
         isStaticRoute = false;
       }
-
-      matchedNodes.push(childNode);
       node = childNode;
     }
+    matchedNodes.push(childNode);
   }
 
-  for (const [depth, node] of matchedNodes.entries()) {
-    node.maxDepth = Math.max(matchedNodes.length - depth, node.maxDepth || 0);
+  console.log(path, "matchedNodes length", matchedNodes.length);
+  for (const [depth, matchedNode] of matchedNodes.entries()) {
+    const prev = matchedNode.maxDepth;
+
+    matchedNode.maxDepth = Math.max(
+      matchedNodes.length - depth,
+      matchedNode.maxDepth || 0,
+    );
+    console.log("sections", sections, "depth", depth);
+    console.log(
+      "prev node.maxDepth",
+      prev,
+      "maybe",
+      matchedNodes.length - depth,
+      "node.maxDepth",
+      sections[depth] ?? " ",
+      matchedNode.maxDepth,
+    );
+    // node.maxDepth = matchedNodes.length - depth;
   }
 
   // Store whatever data was provided into the node

--- a/src/router.ts
+++ b/src/router.ts
@@ -66,8 +66,29 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
       if (node && node.placeholderChildren.length > 1) {
         // https://github.com/unjs/radix3/issues/95
         const remaining = sections.length - i;
+
+        const sortedPlaceholderChildren = [...node.placeholderChildren].sort(
+          (a, b) => {
+            // If both items have maxDepth equal to remaining, no change in order
+            if (a.maxDepth === remaining && b.maxDepth === remaining) {
+              return 0;
+            }
+            // If only item a has maxDepth equal to remaining, it should come before b
+            else if (a.maxDepth === remaining) {
+              return -1;
+            }
+            // If only item b has maxDepth equal to remaining, it should come after a
+            else if (b.maxDepth === remaining) {
+              return 1;
+            }
+            // If maxDepth is not equal to remaining for both items, sort based on their maxDepth
+            else {
+              return b.maxDepth - a.maxDepth;
+            }
+          },
+        );
         node =
-          node.placeholderChildren.find((c) => c.maxDepth === remaining) ||
+          sortedPlaceholderChildren.find((c) => c.maxDepth >= remaining) ||
           null;
       } else {
         node = node.placeholderChildren[0] || null;

--- a/src/router.ts
+++ b/src/router.ts
@@ -71,21 +71,19 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
           (a, b) => {
             if (a.maxDepth === remaining && b.maxDepth === remaining) {
               return 0;
-            }
-            else if (a.maxDepth === remaining) {
+            } else if (a.maxDepth === remaining) {
               return -1;
-            }
-            else if (b.maxDepth === remaining) {
+            } else if (b.maxDepth === remaining) {
               return 1;
-            }
-            else {
+            } else {
               return b.maxDepth - a.maxDepth;
             }
           },
         );
 
         node =
-          sortedPlaceholderChildren.find((c) => c.maxDepth >= remaining) || null;
+          sortedPlaceholderChildren.find((c) => c.maxDepth >= remaining) ||
+          null;
       } else {
         node = node.placeholderChildren[0] || null;
       }

--- a/src/router.ts
+++ b/src/router.ts
@@ -71,11 +71,11 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
           (a, b) =>
             a.maxDepth === remaining && b.maxDepth === remaining
               ? 0
-              : a.maxDepth === remaining
+              : (a.maxDepth === remaining
                 ? -1
                 : b.maxDepth === remaining
                   ? 1
-                  : b.maxDepth - a.maxDepth,
+                  : b.maxDepth - a.maxDepth),
         );
         node =
           sortedPlaceholderChildren.find((c) => c.maxDepth >= remaining) ||

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -139,8 +139,8 @@ describe("Router lookup", function () {
   describe("routes with lower maxDepth should be considered too", function () {
     testRouter(
       [
-        // "/",
-        // "/:packageAndRefOrSha",
+        "/",
+        "/:packageAndRefOrSha",
         "/:owner/:repo/",
         "/:owner/:repo/:packageAndRefOrSha",
         "/:owner/:repo/:npmOrg/:packageAndRefOrSha",

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -139,23 +139,23 @@ describe("Router lookup", function () {
   describe("routes with lower maxDepth should be considered too", function () {
     testRouter(
       [
-        "route/",
-        "route/:packageAndRefOrSha",
-        "route/:owner/:repo/",
-        "route/:owner/:repo/:packageAndRefOrSha",
-        "route/:owner/:repo/:npmOrg/:packageAndRefOrSha",
+        // "/",
+        // "/:packageAndRefOrSha",
+        "/:owner/:repo/",
+        "/:owner/:repo/:packageAndRefOrSha",
+        "/:owner/:repo/:npmOrg/:packageAndRefOrSha",
       ],
       {
-        "route/tinylibs/tinybench/tiny@232": {
-          path: "route/:owner/:repo/:packageAndRefOrSha",
+        "/tinylibs/tinybench/tiny@232": {
+          path: "/:owner/:repo/:packageAndRefOrSha",
           params: {
             owner: "tinylibs",
             repo: "tinybench",
             packageAndRefOrSha: "tiny@232",
           },
         },
-        "route/tinylibs/tinybench/@tinylibs/tiny@232": {
-          path: "route/:owner/:repo/:npmOrg/:packageAndRefOrSha",
+        "/tinylibs/tinybench/@tinylibs/tiny@232": {
+          path: "/:owner/:repo/:npmOrg/:packageAndRefOrSha",
           params: {
             owner: "tinylibs",
             repo: "tinybench",

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -135,6 +135,34 @@ describe("Router lookup", function () {
       "route/with/trailing/slash": { path: "route/with/trailing/slash/" },
     });
   });
+
+  describe("routes with lower maxDepth should be considered too", function () {
+    testRouter(
+      [
+        "route/:owner/:repo/:packageAndRefOrSha",
+        "route/:owner/:repo/:npmOrg/:packageAndRefOrSha",
+      ],
+      {
+        "route/tinylibs/tinybench/tiny@232": {
+          path: "route/:owner/:repo/:packageAndRefOrSha",
+          params: {
+            owner: "tinylibs",
+            repo: "tinybench",
+            packageAndRefOrSha: "tiny@232",
+          },
+        },
+        "route/tinylibs/tinybench/@tinylibs/tiny@232": {
+          path: "route/:owner/:repo/:npmOrg/:packageAndRefOrSha",
+          params: {
+            owner: "tinylibs",
+            repo: "tinybench",
+            npmOrg: "@tinylibs",
+            packageAndRefOrSha: "tiny@232",
+          },
+        },
+      },
+    );
+  });
 });
 
 describe("Router insert", function () {

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -139,6 +139,9 @@ describe("Router lookup", function () {
   describe("routes with lower maxDepth should be considered too", function () {
     testRouter(
       [
+        "route/",
+        "route/:packageAndRefOrSha",
+        "route/:owner/:repo/",
         "route/:owner/:repo/:packageAndRefOrSha",
         "route/:owner/:repo/:npmOrg/:packageAndRefOrSha",
       ],


### PR DESCRIPTION
Resolves https://github.com/unjs/nitro/issues/2419 

The maxDepth was more than `remaining` in some cases. When `server/routes/[owner]/[repo]/[packageAndRefOrSha].get.ts` and `server/routes/[owner]/[repo]/[npmOrg]/[packageAndRefOrSha].get.ts` are present.

The latter would affect the maxDepth, so in such cases, there might be children with lower maxDepth that are candidate. But `===` did not work for those cases, so let's consider those with more maxDepth anyway.

