### PR TITLE
fix!: fallback to dynamic matcher if last segment didn't match

### DIFF
--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -58,7 +58,10 @@ function _lookupTree<T>(
     }
     // Fallback to dynamic for last child (/test and /test/ matches /test/*)
     if (node.param && node.param.methods) {
-      return node.param.methods[method] || node.param.methods[""];
+      const match = node.param.methods[method] || node.param.methods[""];
+      if (match) {
+        return match;
+      }
     }
     if (node.wildcard && node.wildcard.methods) {
       return node.wildcard.methods[method] || node.wildcard.methods[""];

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -15,6 +15,7 @@ describe("Basic router", () => {
     "/test/foo/baz",
     "/test/fooo",
     "/another/path",
+    "/wildcard/**",
   ]);
 
   it("snapshot", () => {
@@ -32,7 +33,9 @@ describe("Basic router", () => {
           │       │       ├── /y ┈> [/test/:idY/y]
           │       │       │       ├── /z ┈> [/test/:idYZ/y/z]
           ├── /another
-          │       ├── /path ┈> [/another/path]"
+          │       ├── /path ┈> [/another/path]
+          ├── /wildcard
+          │       ├── /** ┈> [/wildcard/**]"
     `);
   });
 
@@ -70,6 +73,18 @@ describe("Basic router", () => {
       data: { path: "/test/foo/**" },
       params: { _: "123/456" },
     });
+    expect(findRoute(router, "/wildcard/foo")).toEqual({
+      data: { path: "/wildcard/**" },
+      params: { _: "foo" },
+    });
+    expect(findRoute(router, "/wildcard/foo/bar")).toEqual({
+      data: { path: "/wildcard/**" },
+      params: { _: "foo/bar" },
+    });
+    expect(findRoute(router, "/wildcard")).toEqual({
+      data: { path: "/wildcard/**" },
+      params: { _: "" },
+    });
   });
 
   it("remove works", () => {
@@ -89,7 +104,9 @@ describe("Basic router", () => {
           │       │       ├── /y ┈> [/test/:idY/y]
           │       │       │       ├── /z ┈> [/test/:idYZ/y/z]
           ├── /another
-          │       ├── /path ┈> [/another/path]"
+          │       ├── /path ┈> [/another/path]
+          ├── /wildcard
+          │       ├── /** ┈> [/wildcard/**]"
     `);
     expect(findRoute(router, "/test")).toBeUndefined();
   });


### PR DESCRIPTION
resolves #84

One the problematic issues in radix3 was that if there is only a matcher for `/test/*` or `/test/**`, inputs of `/test` and `/test/` won't match it.

While previous behavior was more restrictive, this is often more initiative that a wildcard handler being able to catch last segment.

If both `/test/* ` and `/test` routes are registered, we still prefer `/test` one. Breaking change is that the fallback does happen.