### PR TITLE
perf: remove strict trailing slash

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,5 +12,6 @@ export default unjs({
     "unicorn/prefer-regexp-test": 0,
     "unicorn/no-array-callback-reference": 0,
     "unicorn/no-array-method-this-argument": 0,
+    "unicorn/prefer-at": 0,
   },
 });

--- a/src/operations/_utils.ts
+++ b/src/operations/_utils.ts
@@ -1,15 +1,3 @@
-import type { RouterContext } from "../types";
-
 export function splitPath(path: string) {
   return path.split("/").filter(Boolean);
-}
-
-export function normalizeTrailingSlash(ctx: RouterContext, path: string = "/") {
-  if (!ctx.options.strictTrailingSlash) {
-    return path;
-  }
-  if (path.length > 1 && path.endsWith("/")) {
-    return path.slice(0, -1);
-  }
-  return path;
 }

--- a/src/operations/add.ts
+++ b/src/operations/add.ts
@@ -1,5 +1,5 @@
 import type { RouterContext, Params } from "../types";
-import { normalizeTrailingSlash, splitPath } from "./_utils";
+import { splitPath } from "./_utils";
 
 /**
  * Add a route to the router context.
@@ -10,8 +10,7 @@ export function addRoute<T>(
   method: string = "",
   data?: T,
 ) {
-  const _path = normalizeTrailingSlash(ctx, path);
-  const segments = splitPath(_path);
+  const segments = splitPath(path);
 
   let node = ctx.root;
 
@@ -71,7 +70,7 @@ export function addRoute<T>(
 
   // Static
   if (!hasParams) {
-    ctx.static[_path] = node;
+    ctx.static[path] = node;
   }
 }
 

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -1,5 +1,5 @@
 import type { RouterContext, MatchedRoute, Node, Params } from "../types";
-import { normalizeTrailingSlash, splitPath } from "./_utils";
+import { splitPath } from "./_utils";
 
 /**
  * Find a route by path.
@@ -10,10 +10,12 @@ export function findRoute<T = unknown>(
   method: string = "",
   opts?: { ignoreParams?: boolean },
 ): MatchedRoute<T> | undefined {
-  const _path = normalizeTrailingSlash(ctx, path);
+  if (path[path.length - 1] === "/") {
+    path = path.slice(0, -1);
+  }
 
   // Static
-  const staticNode = ctx.static[_path];
+  const staticNode = ctx.static[path];
   if (staticNode && staticNode.methods) {
     const staticMatch = staticNode.methods[method] || staticNode.methods[""];
     if (staticMatch !== undefined) {
@@ -22,7 +24,7 @@ export function findRoute<T = unknown>(
   }
 
   // Lookup tree
-  const segments = splitPath(_path);
+  const segments = splitPath(path);
   const match = _lookupTree(ctx, ctx.root, method, segments, 0);
   if (match === undefined) {
     return;

--- a/src/operations/match.ts
+++ b/src/operations/match.ts
@@ -1,5 +1,5 @@
 import type { RouterContext, Node } from "../types";
-import { normalizeTrailingSlash, splitPath } from "./_utils";
+import { splitPath } from "./_utils";
 
 /**
  * Find all route patterns that match the given path.
@@ -9,8 +9,7 @@ export function matchAllRoutes<T>(
   path: string,
   method?: string,
 ): T[] {
-  const _path = normalizeTrailingSlash(ctx, path);
-  return _matchAll(ctx, ctx.root, method || "", splitPath(_path), 0) as T[];
+  return _matchAll(ctx, ctx.root, method || "", splitPath(path), 0) as T[];
 }
 
 function _matchAll<T>(

--- a/src/operations/remove.ts
+++ b/src/operations/remove.ts
@@ -1,5 +1,5 @@
 import type { RouterContext, Node } from "../types";
-import { normalizeTrailingSlash, splitPath } from "./_utils";
+import { splitPath } from "./_utils";
 
 /**
  * Remove a route from the router context.
@@ -9,8 +9,7 @@ export function removeRoute<T>(
   path: string,
   method?: string,
 ) {
-  const _path = normalizeTrailingSlash(ctx, path);
-  const segments = splitPath(_path);
+  const segments = splitPath(path);
   return _remove(ctx.root, method || "", segments, 0);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,4 @@
-export interface RouterOptions {
-  strictTrailingSlash?: boolean;
-}
+export interface RouterOptions {}
 
 export interface RouterContext<T = unknown> {
   options: RouterOptions;


### PR DESCRIPTION
This PR removes the legacy `strictTrailingSlash` option.

With relaxed fallback matcher #110, this option makes less sense and removal of it both gives a consistent behavior (for route matching) and also performance improvement possibility.