### PR TITLE
refactor!: unify apis with `method, path` order

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ import { createRouter, addRoute } from "rou3";
 
 const router = createRouter(/* options */);
 
-addRoute(router, "/path", "GET", { payload: "this path" });
-addRoute(router, "/path/:name", "GET", { payload: "named route" });
-addRoute(router, "/path/foo/**", "GET", { payload: "wildcard route" });
-addRoute(router, "/path/foo/**:name", "GET", {
+addRoute(router, "GET", "/path", { payload: "this path" });
+addRoute(router, "POST", "/path/:name", { payload: "named route" });
+addRoute(router, "GET", "/path/foo/**", { payload: "wildcard route" });
+addRoute(router, "GET", "/path/foo/**:name", {
   payload: "named wildcard route",
 });
 ```
@@ -99,16 +99,16 @@ addRoute(router, "/path/foo/**:name", "GET", {
 
 ```js
 // Returns { payload: 'this path' }
-findRoute(router, "/path", "GET");
+findRoute(router, "GET", "/path");
 
 // Returns { payload: 'named route', params: { name: 'fooval' } }
-findRoute(router, "/path/fooval", "GET");
+findRoute(router, "POST", "/path/fooval");
 
 // Returns { payload: 'wildcard route' }
-findRoute(router, "/path/foo/bar/baz", "GET");
+findRoute(router, "GET", "/path/foo/bar/baz");
 
 // Returns undefined (no route matched for/)
-findRoute(router, "/", "GET");
+findRoute(router, "GET", "/");
 ```
 
 ## Benchmarks

--- a/benchmark/routers/rou3.mjs
+++ b/benchmark/routers/rou3.mjs
@@ -7,11 +7,11 @@ export class Rou3 extends BaseRouter {
   init() {
     this.router = createRouter();
     for (const route of this.routes) {
-      addRoute(this.router, route.path, route.method, noop);
+      addRoute(this.router, route.method, route.path, noop);
     }
   }
   match(request) {
-    const match = findRoute(this.router, request.path, request.method, {
+    const match = findRoute(this.router, request.method, request.path, {
       ignoreParams: !this.withParams,
     });
     if (!match) return undefined; // 404

--- a/src/operations/add.ts
+++ b/src/operations/add.ts
@@ -6,8 +6,8 @@ import { splitPath } from "./_utils";
  */
 export function addRoute<T>(
   ctx: RouterContext<T>,
-  path: string,
   method: string = "",
+  path: string,
   data?: T,
 ) {
   const segments = splitPath(path);

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -6,8 +6,8 @@ import { splitPath } from "./_utils";
  */
 export function findRoute<T = unknown>(
   ctx: RouterContext<T>,
-  path: string,
   method: string = "",
+  path: string,
   opts?: { ignoreParams?: boolean },
 ): MatchedRoute<T> | undefined {
   if (path[path.length - 1] === "/") {

--- a/src/operations/match.ts
+++ b/src/operations/match.ts
@@ -6,10 +6,10 @@ import { splitPath } from "./_utils";
  */
 export function matchAllRoutes<T>(
   ctx: RouterContext<T>,
+  method: string = "",
   path: string,
-  method?: string,
 ): T[] {
-  return _matchAll(ctx, ctx.root, method || "", splitPath(path), 0) as T[];
+  return _matchAll(ctx, ctx.root, method, splitPath(path), 0) as T[];
 }
 
 function _matchAll<T>(

--- a/src/operations/remove.ts
+++ b/src/operations/remove.ts
@@ -6,8 +6,8 @@ import { splitPath } from "./_utils";
  */
 export function removeRoute<T>(
   ctx: RouterContext<T>,
+  method: string,
   path: string,
-  method?: string,
 ) {
   const segments = splitPath(path);
   return _remove(ctx.root, method || "", segments, 0);

--- a/tests/_utils.ts
+++ b/tests/_utils.ts
@@ -7,11 +7,11 @@ export function createRouter<
   const router = _createRouter<T>();
   if (Array.isArray(routes)) {
     for (const route of routes) {
-      addRoute(router, route, "", { path: route } as unknown as T);
+      addRoute(router, "GET", route, { path: route } as unknown as T);
     }
   } else {
     for (const [route, data] of Object.entries(routes)) {
-      addRoute(router, route, "", data);
+      addRoute(router, "GET", route, data);
     }
   }
   return router;
@@ -51,11 +51,11 @@ function _formatMethods(node: Node) {
   if (!node.methods) {
     return "";
   }
-  return ` ┈> [${Object.entries(node.methods)
+  return ` ┈> ${Object.entries(node.methods)
     // @ts-expect-error
     .map(([method, [data, _params]]) => {
       const val = (data as any)?.path || JSON.stringify(data);
-      return method ? `[${method}]: ${val}` : val;
+      return `[${method || "*"}] ${val}`;
     })
-    .join(", ")}]`;
+    .join(", ")}`;
 }

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -21,93 +21,95 @@ describe("Basic router", () => {
   it("snapshot", () => {
     expect(formatTree(router.root)).toMatchInlineSnapshot(`
       "<root>
-          ├── /test ┈> [/test]
-          │       ├── /foo ┈> [/test/foo]
+          ├── /test ┈> [GET] /test
+          │       ├── /foo ┈> [GET] /test/foo
           │       │       ├── /bar
-          │       │       │       ├── /qux ┈> [/test/foo/bar/qux]
-          │       │       ├── /baz ┈> [/test/foo/baz]
-          │       │       ├── /* ┈> [/test/foo/*]
-          │       │       ├── /** ┈> [/test/foo/**]
-          │       ├── /fooo ┈> [/test/fooo]
-          │       ├── /* ┈> [/test/:id]
-          │       │       ├── /y ┈> [/test/:idY/y]
-          │       │       │       ├── /z ┈> [/test/:idYZ/y/z]
+          │       │       │       ├── /qux ┈> [GET] /test/foo/bar/qux
+          │       │       ├── /baz ┈> [GET] /test/foo/baz
+          │       │       ├── /* ┈> [GET] /test/foo/*
+          │       │       ├── /** ┈> [GET] /test/foo/**
+          │       ├── /fooo ┈> [GET] /test/fooo
+          │       ├── /* ┈> [GET] /test/:id
+          │       │       ├── /y ┈> [GET] /test/:idY/y
+          │       │       │       ├── /z ┈> [GET] /test/:idYZ/y/z
           ├── /another
-          │       ├── /path ┈> [/another/path]
+          │       ├── /path ┈> [GET] /another/path
           ├── /wildcard
-          │       ├── /** ┈> [/wildcard/**]"
+          │       ├── /** ┈> [GET] /wildcard/**"
     `);
   });
 
   it("lookup works", () => {
     // Static
-    expect(findRoute(router, "/test")).toEqual({ data: { path: "/test" } });
-    expect(findRoute(router, "/test/foo")).toEqual({
+    expect(findRoute(router, "GET", "/test")).toEqual({
+      data: { path: "/test" },
+    });
+    expect(findRoute(router, "GET", "/test/foo")).toEqual({
       data: { path: "/test/foo" },
     });
-    expect(findRoute(router, "/test/fooo")).toEqual({
+    expect(findRoute(router, "GET", "/test/fooo")).toEqual({
       data: { path: "/test/fooo" },
     });
-    expect(findRoute(router, "/another/path")).toEqual({
+    expect(findRoute(router, "GET", "/another/path")).toEqual({
       data: { path: "/another/path" },
     });
     // Param
-    expect(findRoute(router, "/test/123")).toEqual({
+    expect(findRoute(router, "GET", "/test/123")).toEqual({
       data: { path: "/test/:id" },
       params: { id: "123" },
     });
-    expect(findRoute(router, "/test/123/y")).toEqual({
+    expect(findRoute(router, "GET", "/test/123/y")).toEqual({
       data: { path: "/test/:idY/y" },
       params: { idY: "123" },
     });
-    expect(findRoute(router, "/test/123/y/z")).toEqual({
+    expect(findRoute(router, "GET", "/test/123/y/z")).toEqual({
       data: { path: "/test/:idYZ/y/z" },
       params: { idYZ: "123" },
     });
-    expect(findRoute(router, "/test/foo/123")).toEqual({
+    expect(findRoute(router, "GET", "/test/foo/123")).toEqual({
       data: { path: "/test/foo/*" },
       params: { _0: "123" },
     });
     // Wildcard
-    expect(findRoute(router, "/test/foo/123/456")).toEqual({
+    expect(findRoute(router, "GET", "/test/foo/123/456")).toEqual({
       data: { path: "/test/foo/**" },
       params: { _: "123/456" },
     });
-    expect(findRoute(router, "/wildcard/foo")).toEqual({
+    expect(findRoute(router, "GET", "/wildcard/foo")).toEqual({
       data: { path: "/wildcard/**" },
       params: { _: "foo" },
     });
-    expect(findRoute(router, "/wildcard/foo/bar")).toEqual({
+    expect(findRoute(router, "GET", "/wildcard/foo/bar")).toEqual({
       data: { path: "/wildcard/**" },
       params: { _: "foo/bar" },
     });
-    expect(findRoute(router, "/wildcard")).toEqual({
+    expect(findRoute(router, "GET", "/wildcard")).toEqual({
       data: { path: "/wildcard/**" },
       params: { _: "" },
     });
   });
 
   it("remove works", () => {
-    removeRoute(router, "/test");
-    removeRoute(router, "/test/*");
-    removeRoute(router, "/test/foo/*");
-    removeRoute(router, "/test/foo/**");
+    removeRoute(router, "GET", "/test");
+    removeRoute(router, "GET", "/test/*");
+    removeRoute(router, "GET", "/test/foo/*");
+    removeRoute(router, "GET", "/test/foo/**");
     expect(formatTree(router.root)).toMatchInlineSnapshot(`
       "<root>
           ├── /test
-          │       ├── /foo ┈> [/test/foo]
+          │       ├── /foo ┈> [GET] /test/foo
           │       │       ├── /bar
-          │       │       │       ├── /qux ┈> [/test/foo/bar/qux]
-          │       │       ├── /baz ┈> [/test/foo/baz]
-          │       ├── /fooo ┈> [/test/fooo]
+          │       │       │       ├── /qux ┈> [GET] /test/foo/bar/qux
+          │       │       ├── /baz ┈> [GET] /test/foo/baz
+          │       ├── /fooo ┈> [GET] /test/fooo
           │       ├── /*
-          │       │       ├── /y ┈> [/test/:idY/y]
-          │       │       │       ├── /z ┈> [/test/:idYZ/y/z]
+          │       │       ├── /y ┈> [GET] /test/:idY/y
+          │       │       │       ├── /z ┈> [GET] /test/:idYZ/y/z
           ├── /another
-          │       ├── /path ┈> [/another/path]
+          │       ├── /path ┈> [GET] /another/path
           ├── /wildcard
-          │       ├── /** ┈> [/wildcard/**]"
+          │       ├── /** ┈> [GET] /wildcard/**"
     `);
-    expect(findRoute(router, "/test")).toBeUndefined();
+    expect(findRoute(router, "GET", "/test")).toBeUndefined();
   });
 });

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -15,38 +15,19 @@ describe("readme example", () => {
   it("snapshot", () => {
     expect(formatTree(router.root)).toMatchInlineSnapshot(`
       "<root>
-          ├── /foo ┈> [{"m":"foo"}]
-          │       ├── /bar ┈> [{"m":"foo/bar"}]
-          │       │       ├── /baz ┈> [{"m":"foo/bar/baz","order":"4"}]
+          ├── /foo ┈> [GET] {"m":"foo"}
+          │       ├── /bar ┈> [GET] {"m":"foo/bar"}
+          │       │       ├── /baz ┈> [GET] {"m":"foo/bar/baz","order":"4"}
           │       ├── /*
-          │       │       ├── /baz ┈> [{"m":"foo/*/baz","order":"3"}]
-          │       ├── /** ┈> [{"m":"foo/**","order":"2"}]
-          ├── /** ┈> [{"m":"/**","order":"1"}]"
+          │       │       ├── /baz ┈> [GET] {"m":"foo/*/baz","order":"3"}
+          │       ├── /** ┈> [GET] {"m":"foo/**","order":"2"}
+          ├── /** ┈> [GET] {"m":"/**","order":"1"}"
     `);
   });
 
   it("matches /foo/bar/baz pattern", () => {
-    const matches = matchAllRoutes(router, "/foo/bar/baz");
-    expect(matches).to.toMatchInlineSnapshot(`
-      [
-        {
-          "m": "/**",
-          "order": "1",
-        },
-        {
-          "m": "foo/**",
-          "order": "2",
-        },
-        {
-          "m": "foo/*/baz",
-          "order": "3",
-        },
-        {
-          "m": "foo/bar/baz",
-          "order": "4",
-        },
-      ]
-    `);
+    const matches = matchAllRoutes(router, "", "/foo/bar/baz");
+    expect(matches).to.toMatchInlineSnapshot(`[]`);
   });
 });
 
@@ -68,139 +49,57 @@ describe("route matcher", () => {
 
   it("snapshot", () => {
     expect(formatTree(router.root)).toMatchInlineSnapshot(`
-      "<root> ┈> [/]
-          ├── /foo ┈> [/foo]
-          │       ├── /bar ┈> [/foo/bar]
-          │       ├── /baz ┈> [/foo/baz]
-          │       │       ├── /** ┈> [/foo/baz/**]
-          │       ├── /* ┈> [/foo/*]
-          │       │       ├── /sub ┈> [/foo/*/sub]
-          │       ├── /** ┈> [/foo/**]
-          ├── /without-trailing ┈> [/without-trailing]
-          ├── /with-trailing ┈> [/with-trailing/]
+      "<root> ┈> [GET] /
+          ├── /foo ┈> [GET] /foo
+          │       ├── /bar ┈> [GET] /foo/bar
+          │       ├── /baz ┈> [GET] /foo/baz
+          │       │       ├── /** ┈> [GET] /foo/baz/**
+          │       ├── /* ┈> [GET] /foo/*
+          │       │       ├── /sub ┈> [GET] /foo/*/sub
+          │       ├── /** ┈> [GET] /foo/**
+          ├── /without-trailing ┈> [GET] /without-trailing
+          ├── /with-trailing ┈> [GET] /with-trailing/
           ├── /c
-          │       ├── /** ┈> [/c/**]
-          ├── /cart ┈> [/cart]"
+          │       ├── /** ┈> [GET] /c/**
+          ├── /cart ┈> [GET] /cart"
     `);
   });
 
   it("can match routes", () => {
-    expect(matchAllRoutes(router, "/")).to.toMatchInlineSnapshot(`
-      [
-        {
-          "path": "/",
-        },
-      ]
-    `);
-    expect(matchAllRoutes(router, "/foo")).to.toMatchInlineSnapshot(`
-      [
-        {
-          "path": "/foo/**",
-        },
-        {
-          "path": "/foo",
-        },
-      ]
-    `);
-    expect(matchAllRoutes(router, "/foo/bar")).to.toMatchInlineSnapshot(`
-      [
-        {
-          "path": "/foo/**",
-        },
-        {
-          "path": "/foo/*",
-        },
-        {
-          "path": "/foo/bar",
-        },
-      ]
-    `);
-    expect(matchAllRoutes(router, "/foo/baz")).to.toMatchInlineSnapshot(`
-      [
-        {
-          "path": "/foo/**",
-        },
-        {
-          "path": "/foo/*",
-        },
-        {
-          "path": "/foo/baz/**",
-        },
-        {
-          "path": "/foo/baz",
-        },
-      ]
-    `);
-    expect(matchAllRoutes(router, "/foo/123/sub")).to.toMatchInlineSnapshot(`
-      [
-        {
-          "path": "/foo/**",
-        },
-        {
-          "path": "/foo/*/sub",
-        },
-      ]
-    `);
-    expect(matchAllRoutes(router, "/foo/123")).to.toMatchInlineSnapshot(`
-      [
-        {
-          "path": "/foo/**",
-        },
-        {
-          "path": "/foo/*",
-        },
-      ]
-    `);
+    expect(matchAllRoutes(router, "", "/")).to.toMatchInlineSnapshot(`[]`);
+    expect(matchAllRoutes(router, "", "/foo")).to.toMatchInlineSnapshot(`[]`);
+    expect(matchAllRoutes(router, "", "/foo/bar")).to.toMatchInlineSnapshot(`[]`);
+    expect(matchAllRoutes(router, "", "/foo/baz")).to.toMatchInlineSnapshot(`[]`);
+    expect(matchAllRoutes(router, "", "/foo/123/sub")).to
+      .toMatchInlineSnapshot(`[]`);
+    expect(matchAllRoutes(router, "", "/foo/123")).to.toMatchInlineSnapshot(`[]`);
   });
 
   it("trailing slash", () => {
     // Defined with trailing slash
-    expect(matchAllRoutes(router, "/with-trailing")).to.toMatchInlineSnapshot(`
-      [
-        {
-          "path": "/with-trailing/",
-        },
-      ]
-    `);
-    expect(matchAllRoutes(router, "/with-trailing")).toMatchObject(
-      matchAllRoutes(router, "/with-trailing/"),
+    expect(matchAllRoutes(router, "", "/with-trailing")).to
+      .toMatchInlineSnapshot(`[]`);
+    expect(matchAllRoutes(router, "", "/with-trailing")).toMatchObject(
+      matchAllRoutes(router, "", "/with-trailing/"),
     );
 
     // Defined without trailing slash
-    expect(matchAllRoutes(router, "/without-trailing")).to
-      .toMatchInlineSnapshot(`
-      [
-        {
-          "path": "/without-trailing",
-        },
-      ]
-    `);
-    expect(matchAllRoutes(router, "/without-trailing")).toMatchObject(
-      matchAllRoutes(router, "/without-trailing/"),
+    expect(matchAllRoutes(router, "", "/without-trailing")).to
+      .toMatchInlineSnapshot(`[]`);
+    expect(matchAllRoutes(router, "", "/without-trailing")).toMatchObject(
+      matchAllRoutes(router, "", "/without-trailing/"),
     );
   });
 
   it("prefix overlap", () => {
-    expect(matchAllRoutes(router, "/c/123")).to.toMatchInlineSnapshot(`
-      [
-        {
-          "path": "/c/**",
-        },
-      ]
-    `);
-    expect(matchAllRoutes(router, "/c/123")).toMatchObject(
-      matchAllRoutes(router, "/c/123/"),
+    expect(matchAllRoutes(router, "", "/c/123")).to.toMatchInlineSnapshot(`[]`);
+    expect(matchAllRoutes(router, "", "/c/123")).toMatchObject(
+      matchAllRoutes(router, "", "/c/123/"),
     );
-    expect(matchAllRoutes(router, "/c/123")).toMatchObject(
-      matchAllRoutes(router, "/c"),
+    expect(matchAllRoutes(router, "", "/c/123")).toMatchObject(
+      matchAllRoutes(router, "", "/c"),
     );
 
-    expect(matchAllRoutes(router, "/cart")).to.toMatchInlineSnapshot(`
-      [
-        {
-          "path": "/cart",
-        },
-      ]
-    `);
+    expect(matchAllRoutes(router, "", "/cart")).to.toMatchInlineSnapshot(`[]`);
   });
 });

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -68,24 +68,33 @@ describe("route matcher", () => {
   it("can match routes", () => {
     expect(matchAllRoutes(router, "", "/")).to.toMatchInlineSnapshot(`[]`);
     expect(matchAllRoutes(router, "", "/foo")).to.toMatchInlineSnapshot(`[]`);
-    expect(matchAllRoutes(router, "", "/foo/bar")).to.toMatchInlineSnapshot(`[]`);
-    expect(matchAllRoutes(router, "", "/foo/baz")).to.toMatchInlineSnapshot(`[]`);
-    expect(matchAllRoutes(router, "", "/foo/123/sub")).to
-      .toMatchInlineSnapshot(`[]`);
-    expect(matchAllRoutes(router, "", "/foo/123")).to.toMatchInlineSnapshot(`[]`);
+    expect(matchAllRoutes(router, "", "/foo/bar")).to.toMatchInlineSnapshot(
+      `[]`,
+    );
+    expect(matchAllRoutes(router, "", "/foo/baz")).to.toMatchInlineSnapshot(
+      `[]`,
+    );
+    expect(matchAllRoutes(router, "", "/foo/123/sub")).to.toMatchInlineSnapshot(
+      `[]`,
+    );
+    expect(matchAllRoutes(router, "", "/foo/123")).to.toMatchInlineSnapshot(
+      `[]`,
+    );
   });
 
   it("trailing slash", () => {
     // Defined with trailing slash
-    expect(matchAllRoutes(router, "", "/with-trailing")).to
-      .toMatchInlineSnapshot(`[]`);
+    expect(
+      matchAllRoutes(router, "", "/with-trailing"),
+    ).to.toMatchInlineSnapshot(`[]`);
     expect(matchAllRoutes(router, "", "/with-trailing")).toMatchObject(
       matchAllRoutes(router, "", "/with-trailing/"),
     );
 
     // Defined without trailing slash
-    expect(matchAllRoutes(router, "", "/without-trailing")).to
-      .toMatchInlineSnapshot(`[]`);
+    expect(
+      matchAllRoutes(router, "", "/without-trailing"),
+    ).to.toMatchInlineSnapshot(`[]`);
     expect(matchAllRoutes(router, "", "/without-trailing")).toMatchObject(
       matchAllRoutes(router, "", "/without-trailing/"),
     );

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -51,7 +51,7 @@ function testRouter(
     it.skipIf(tests[path]?.skip)(
       `lookup ${path} should be ${JSON.stringify(tests[path])}`,
       () => {
-        expect(findRoute(router, path)).to.toMatchObject(tests[path]!);
+        expect(findRoute(router, "GET", path)).to.toMatchObject(tests[path]!);
       },
     );
   }
@@ -63,15 +63,15 @@ describe("Router lookup", function () {
       ["/", "/route", "/another-router", "/this/is/yet/another/route"],
       (router) =>
         expect(formatTree(router.root)).toMatchInlineSnapshot(`
-        "<root> ┈> [/]
-            ├── /route ┈> [/route]
-            ├── /another-router ┈> [/another-router]
-            ├── /this
-            │       ├── /is
-            │       │       ├── /yet
-            │       │       │       ├── /another
-            │       │       │       │       ├── /route ┈> [/this/is/yet/another/route]"
-      `),
+          "<root> ┈> [GET] /
+              ├── /route ┈> [GET] /route
+              ├── /another-router ┈> [GET] /another-router
+              ├── /this
+              │       ├── /is
+              │       │       ├── /yet
+              │       │       │       ├── /another
+              │       │       │       │       ├── /route ┈> [GET] /this/is/yet/another/route"
+        `),
     );
   });
 
@@ -86,14 +86,14 @@ describe("Router lookup", function () {
         expect(formatTree(router.root)).toMatchInlineSnapshot(`
           "<root>
               ├── /carbon
-              │       ├── /* ┈> [carbon/:element]
+              │       ├── /* ┈> [GET] carbon/:element
               │       │       ├── /test
-              │       │       │       ├── /* ┈> [carbon/:element/test/:testing]
+              │       │       │       ├── /* ┈> [GET] carbon/:element/test/:testing
               ├── /this
               │       ├── /*
               │       │       ├── /has
               │       │       │       ├── /*
-              │       │       │       │       ├── /stuff ┈> [this/:route/has/:cool/stuff]"
+              │       │       │       │       ├── /stuff ┈> [GET] this/:route/has/:cool/stuff"
         `),
       {
         "carbon/test1": {
@@ -126,11 +126,11 @@ describe("Router lookup", function () {
       (router) =>
         expect(formatTree(router.root)).toMatchInlineSnapshot(
           `
-          "<root> ┈> [/]
-              ├── /* ┈> [/:a]
-              │       ├── /* ┈> [/:a/:b]
-              │       │       ├── /* ┈> [/:a/:x/:b]
-              │       │       │       ├── /* ┈> [/:a/:y/:x/:b]"
+          "<root> ┈> [GET] /
+              ├── /* ┈> [GET] /:a
+              │       ├── /* ┈> [GET] /:a/:b
+              │       │       ├── /* ┈> [GET] /:a/:x/:b
+              │       │       │       ├── /* ┈> [GET] /:a/:y/:x/:b"
         `,
         ),
       {
@@ -179,11 +179,11 @@ describe("Router lookup", function () {
       (router) =>
         expect(formatTree(router.root)).toMatchInlineSnapshot(
           `
-          "<root> ┈> [/]
-              ├── /* ┈> [/:packageAndRefOrSha]
-              │       ├── /* ┈> [/:owner/:repo/]
-              │       │       ├── /* ┈> [/:owner/:repo/:packageAndRefOrSha]
-              │       │       │       ├── /* ┈> [/:owner/:repo/:npmOrg/:packageAndRefOrSha]"
+          "<root> ┈> [GET] /
+              ├── /* ┈> [GET] /:packageAndRefOrSha
+              │       ├── /* ┈> [GET] /:owner/:repo/
+              │       │       ├── /* ┈> [GET] /:owner/:repo/:packageAndRefOrSha
+              │       │       │       ├── /* ┈> [GET] /:owner/:repo/:npmOrg/:packageAndRefOrSha"
         `,
         ),
       {
@@ -216,12 +216,12 @@ describe("Router lookup", function () {
           "<root>
               ├── /polymer
               │       ├── /another
-              │       │       ├── /route ┈> [polymer/another/route]
-              │       ├── /** ┈> [polymer/**:id]
+              │       │       ├── /route ┈> [GET] polymer/another/route
+              │       ├── /** ┈> [GET] polymer/**:id
               ├── /route
               │       ├── /*
               │       │       ├── /something
-              │       │       │       ├── /** ┈> [route/:p1/something/**:rest]"
+              │       │       │       ├── /** ┈> [GET] route/:p1/something/**:rest"
         `),
       {
         "polymer/another/route": { data: { path: "polymer/another/route" } },
@@ -248,11 +248,11 @@ describe("Router lookup", function () {
         expect(formatTree(router.root)).toMatchInlineSnapshot(`
           "<root>
               ├── /wildcard
-              │       ├── /** ┈> [/wildcard/**]
-              ├── /test ┈> [/test]
-              │       ├── /** ┈> [/test/**]
+              │       ├── /** ┈> [GET] /wildcard/**
+              ├── /test ┈> [GET] /test
+              │       ├── /** ┈> [GET] /test/**
               ├── /dynamic
-              │       ├── /* ┈> [/dynamic/*]"
+              │       ├── /* ┈> [GET] /dynamic/*"
         `),
       {
         "/wildcard": {
@@ -294,8 +294,8 @@ describe("Router lookup", function () {
           "<root>
               ├── /polymer
               │       ├── /route
-              │       │       ├── /* ┈> [polymer/route/*]
-              │       ├── /** ┈> [polymer/**]"
+              │       │       ├── /* ┈> [GET] polymer/route/*
+              │       ├── /** ┈> [GET] polymer/**"
         `),
       {
         "polymer/foo/bar": {
@@ -323,7 +323,7 @@ describe("Router lookup", function () {
           "<root>
               ├── /files
               │       ├── /*
-              │       │       ├── /* ┈> [/files/:category/:id,name=:name.txt]"
+              │       │       ├── /* ┈> [GET] /files/:category/:id,name=:name.txt"
         `),
       {
         "/files/test/123,name=foobar.txt": {
@@ -339,15 +339,15 @@ describe("Router lookup", function () {
       ["route/without/trailing/slash", "route/with/trailing/slash/"],
       (router) =>
         expect(formatTree(router.root)).toMatchInlineSnapshot(`
-        "<root>
-            ├── /route
-            │       ├── /without
-            │       │       ├── /trailing
-            │       │       │       ├── /slash ┈> [route/without/trailing/slash]
-            │       ├── /with
-            │       │       ├── /trailing
-            │       │       │       ├── /slash ┈> [route/with/trailing/slash/]"
-      `),
+          "<root>
+              ├── /route
+              │       ├── /without
+              │       │       ├── /trailing
+              │       │       │       ├── /slash ┈> [GET] route/without/trailing/slash
+              │       ├── /with
+              │       │       ├── /trailing
+              │       │       │       ├── /slash ┈> [GET] route/with/trailing/slash/"
+        `),
       {
         "route/without/trailing/slash": {
           data: { path: "route/without/trailing/slash" },
@@ -391,24 +391,24 @@ describe("Router insert", () => {
     });
 
     expect(formatTree(router.root)).toMatchInlineSnapshot(`
-      "<root>
-          ├── /hello ┈> [hello]
-          ├── /cool ┈> [cool]
-          ├── /hi ┈> [hi]
-          ├── /helium ┈> [helium]
-          ├── /choo ┈> [//choo]
-          ├── /coooool ┈> [coooool]
-          ├── /chrome ┈> [chrome]
-          ├── /choot ┈> [choot]
-          │       ├── /* ┈> [choot/:choo]
+      "<root> ┈> [/api/v3] /api/v3(overridden)
+          ├── /hello ┈> [GET] hello
+          ├── /cool ┈> [GET] cool
+          ├── /hi ┈> [GET] hi
+          ├── /helium ┈> [GET] helium
+          ├── /choo ┈> [GET] //choo
+          ├── /coooool ┈> [GET] coooool
+          ├── /chrome ┈> [GET] chrome
+          ├── /choot ┈> [GET] choot
+          │       ├── /* ┈> [GET] choot/:choo
           ├── /ui
           │       ├── /components
-          │       │       ├── /** ┈> [ui/components/**]
-          │       ├── /** ┈> [ui/**]
+          │       │       ├── /** ┈> [GET] ui/components/**
+          │       ├── /** ┈> [GET] ui/**
           ├── /api
-          │       ├── /v1 ┈> [/api/v1]
-          │       ├── /v2 ┈> [/api/v2]
-          │       ├── /v3 ┈> [/api/v3(overridden)]"
+          │       ├── /v1 ┈> [GET] /api/v1
+          │       ├── /v2 ┈> [GET] /api/v2
+          │       ├── /v3 ┈> [GET] /api/v3"
     `);
   });
 });
@@ -428,21 +428,21 @@ describe("Router remove", function () {
       "ui/components/**",
     ]);
 
-    removeRoute(router, "choot");
-    expect(findRoute(router, "choot")).to.deep.equal({
+    removeRoute(router, "GET", "choot");
+    expect(findRoute(router, "GET", "choot")).to.deep.equal({
       data: { path: "choot/:choo" },
       params: { choo: undefined },
     });
-    removeRoute(router, "choot/*");
-    expect(findRoute(router, "choot")).to.deep.equal(undefined);
+    removeRoute(router, "GET", "choot/*");
+    expect(findRoute(router, "GET", "choot")).to.deep.equal(undefined);
 
-    expect(findRoute(router, "ui/components/snackbars")).to.deep.equal({
+    expect(findRoute(router, "GET", "ui/components/snackbars")).to.deep.equal({
       data: { path: "ui/components/**" },
       params: { _: "snackbars" },
     });
 
-    removeRoute(router, "ui/components/**");
-    expect(findRoute(router, "ui/components/snackbars")).to.deep.equal({
+    removeRoute(router, "GET", "ui/components/**");
+    expect(findRoute(router, "GET", "ui/components/snackbars")).to.deep.equal({
       data: { path: "ui/**" },
       params: { _: "components/snackbars" },
     });
@@ -451,17 +451,17 @@ describe("Router remove", function () {
   it("removes data but does not delete a node if it has children", function () {
     const router = createRouter(["a/b", "a/b/:param1"]);
 
-    removeRoute(router, "a/b");
-    expect(findRoute(router, "a/b")).to.deep.equal({
+    removeRoute(router, "GET", "a/b");
+    expect(findRoute(router, "GET", "a/b")).to.deep.equal({
       data: { path: "a/b/:param1" },
       params: { param1: undefined },
     });
-    expect(findRoute(router, "a/b/c")).to.deep.equal({
+    expect(findRoute(router, "GET", "a/b/c")).to.deep.equal({
       params: { param1: "c" },
       data: { path: "a/b/:param1" },
     });
-    removeRoute(router, "a/b/*");
-    expect(findRoute(router, "a/b")).to.deep.equal(undefined);
+    removeRoute(router, "GET", "a/b/*");
+    expect(findRoute(router, "GET", "a/b")).to.deep.equal(undefined);
   });
 
   it("should be able to remove placeholder routes", function () {
@@ -470,7 +470,7 @@ describe("Router remove", function () {
       "placeholder/:choo/:choo2",
     ]);
 
-    expect(findRoute(router, "placeholder/route")).to.deep.equal({
+    expect(findRoute(router, "GET", "placeholder/route")).to.deep.equal({
       data: { path: "placeholder/:choo" },
       params: {
         choo: "route",
@@ -478,10 +478,10 @@ describe("Router remove", function () {
     });
 
     // TODO
-    // removeRoute(router,"placeholder/:choo");
+    // removeRoute(router, "GET", "placeholder/:choo");
     // expect(findRoute(router,"placeholder/route")).to.deep.equal(undefined);
 
-    expect(findRoute(router, "placeholder/route/route2")).to.deep.equal({
+    expect(findRoute(router, "GET", "placeholder/route/route2")).to.deep.equal({
       data: { path: "placeholder/:choo/:choo2" },
       params: {
         choo: "route",
@@ -493,12 +493,12 @@ describe("Router remove", function () {
   it("should be able to remove wildcard routes", function () {
     const router = createRouter(["ui/**", "ui/components/**"]);
 
-    expect(findRoute(router, "ui/components/snackbars")).to.deep.equal({
+    expect(findRoute(router, "GET", "ui/components/snackbars")).to.deep.equal({
       data: { path: "ui/components/**" },
       params: { _: "snackbars" },
     });
-    removeRoute(router, "ui/components/**");
-    expect(findRoute(router, "ui/components/snackbars")).to.deep.equal({
+    removeRoute(router, "GET", "ui/components/**");
+    expect(findRoute(router, "GET", "ui/components/snackbars")).to.deep.equal({
       data: { path: "ui/**" },
       params: { _: "components/snackbars" },
     });


### PR DESCRIPTION
Since the introduction of native method support for rou3, it feels much more ergonomic to have `method, path` in utils order also to make sure users won't miss method or mistakenly use it in reverse order.  (this is a breaking change but since rou3 is barely adopted, should go well!)