### PR TITLE
test: add benchmark tests

### DIFF
--- a/tests/bench/bench.bench.ts
+++ b/tests/bench/bench.bench.ts
@@ -1,0 +1,14 @@
+import { bench, describe } from "vitest";
+import { requests, createBenchApps } from "./spec";
+
+const apps = createBenchApps();
+
+for (const request of requests) {
+  describe(`[${request.method}] ${request.path}`, () => {
+    for (const [name, _find] of apps) {
+      bench(name, () => {
+        _find(request.method, request.path);
+      });
+    }
+  });
+}

--- a/tests/bench/bench.test.ts
+++ b/tests/bench/bench.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { requests, createBenchApps } from "./spec";
+
+describe("benchmark", () => {
+  const apps = createBenchApps();
+  describe("app works as expected", () => {
+    for (const [name, _find] of apps) {
+      for (const request of requests) {
+        it(`[${name}] [${request.method}] ${request.path}`, async () => {
+          const match = _find(request.method, request.path);
+          expect(match).toBeDefined();
+          expect(match.params).toEqual(request.params);
+          expect(match.data).toEqual(request.data);
+        });
+      }
+    }
+  });
+});

--- a/tests/bench/bundle.test.ts
+++ b/tests/bench/bundle.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { build } from "esbuild";
+import { fileURLToPath } from "node:url";
+import zlib from "node:zlib";
+
+describe("benchmark", () => {
+  it("bundle size", async () => {
+    const code = /* js */ `
+      import { createRouter, addRoute, findRoute, matchAllRoutes } from "../../dist/index.mjs";
+      const router = createRouter();
+      addRoute(router, "GET", "/hello", { path: "/hello" });
+      findRoute(router, "GET", "/hello");
+      matchAllRoutes(router, "GET", "/hello");
+    `;
+    const { bytes, gzipSize } = await getBundleSize(code);
+    // console.log("bundle size", { bytes, gzipSize });
+    expect(bytes).toBeLessThanOrEqual(2500); // <2.5kb
+    expect(gzipSize).toBeLessThanOrEqual(1000); // <1kb
+  });
+});
+
+async function getBundleSize(code: string) {
+  const res = await build({
+    bundle: true,
+    metafile: true,
+    write: false,
+    minify: true,
+    format: "esm",
+    platform: "node",
+    outfile: "index.mjs",
+    stdin: {
+      contents: code,
+      resolveDir: fileURLToPath(new URL(".", import.meta.url)),
+      sourcefile: "index.mjs",
+      loader: "js",
+    },
+  });
+  const { bytes } = res.metafile.outputs["index.mjs"];
+  const gzipSize = zlib.gzipSync(res.outputFiles[0].text).byteLength;
+  return { bytes, gzipSize };
+}

--- a/tests/bench/spec.ts
+++ b/tests/bench/spec.ts
@@ -1,0 +1,101 @@
+import * as rou3 from "../../src";
+
+// https://github.com/pi0/web-framework-benchmarks
+// (based on hono router benchmarks)
+
+export const routes = [
+  { method: "GET", path: "/user" },
+  { method: "GET", path: "/user/comments" },
+  { method: "GET", path: "/user/avatar" },
+  { method: "GET", path: "/user/lookup/username/:username" },
+  { method: "GET", path: "/user/lookup/email/:address" },
+  { method: "GET", path: "/event/:id" },
+  { method: "GET", path: "/event/:id/comments" },
+  { method: "POST", path: "/event/:id/comment" },
+  { method: "GET", path: "/map/:location/events" },
+  { method: "GET", path: "/status" },
+  { method: "GET", path: "/very/deeply/nested/route/hello/there" },
+  { method: "GET", path: "/static/:path" },
+];
+
+export const requests = [
+  {
+    name: "short static",
+    method: "GET",
+    path: "/user",
+    data: "[GET] /user",
+  },
+  {
+    name: "static with same radix",
+    method: "GET",
+    path: "/user/comments",
+    data: "[GET] /user/comments",
+  },
+  {
+    name: "dynamic route",
+    method: "GET",
+    path: "/user/lookup/username/hey",
+    params: { username: "hey" },
+    data: "[GET] /user/lookup/username/:username",
+  },
+  {
+    name: "mixed static dynamic",
+    method: "GET",
+    path: "/event/abcd1234/comments",
+    params: { id: "abcd1234" },
+    data: "[GET] /event/:id/comments",
+  },
+  {
+    name: "post",
+    method: "POST",
+    path: "/event/abcd1234/comment",
+    params: { id: "abcd1234" },
+    data: "[POST] /event/:id/comment",
+  },
+  {
+    name: "long static",
+    method: "GET",
+    path: "/very/deeply/nested/route/hello/there",
+    data: "[GET] /very/deeply/nested/route/hello/there",
+  },
+  {
+    name: "wildcard",
+    method: "GET",
+    path: "/static/index.html",
+    params: { path: "index.html" },
+    data: "[GET] /static/:path",
+  },
+];
+
+export function createBenchApps() {
+  return [
+    ["rou3", createRou3Router()],
+    ["fastest", createFastestRouter()],
+  ] as const;
+}
+
+export function createRou3Router() {
+  const router = rou3.createRouter();
+  for (const route of routes) {
+    rou3.addRoute(
+      router,
+      route.method,
+      route.path,
+      `[${route.method}] ${route.path}`,
+    );
+  }
+  return (method: string, path: string) => {
+    return rou3.findRoute(router, method, path);
+  };
+}
+
+export function createFastestRouter() {
+  const staticMap = Object.create(null);
+  for (const req of requests) {
+    staticMap[req.method] = staticMap[req.method] || Object.create(null);
+    staticMap[req.method][req.path] = req;
+  }
+  return (method: string, path: string) => {
+    return staticMap[method]?.[path];
+  };
+}


### PR DESCRIPTION
Add bench test scripts that compare rou3 with maximum runtime native performance (as if we just use a map of all known requests) ... final goal is to get closer to `1x` by improving things.

Also bundle test makes sure we keep under promise of a specific upper limit (today: 2.5kb/1kb with all `createRouter, addRoute, findRoute, matchAllRoutes`)

Today:

<img width="875" alt="image" src="https://github.com/unjs/rou3/assets/5158436/20616498-3d10-4a41-b032-69423e329154">

<img width="619" alt="image" src="https://github.com/unjs/rou3/assets/5158436/ec83b943-c0f2-4669-9946-12731e9243e2">
