### PR TITLE
feat!: support multiple entries with same route

### DIFF
--- a/src/operations/add.ts
+++ b/src/operations/add.ts
@@ -65,11 +65,13 @@ export function addRoute<T>(
   if (!node.methods) {
     node.methods = Object.create(null);
   }
-  node.methods![method] = {
+  if (!node.methods![method]) {
+    node.methods![method] = [];
+  }
+  node.methods![method].push({
     data: data || (null as T),
     paramsMap: hasParams ? paramsMap : undefined,
-  };
-  node.index = segments.length - 1;
+  });
 
   // Static
   if (!hasParams) {

--- a/src/operations/find-all.ts
+++ b/src/operations/find-all.ts
@@ -14,18 +14,18 @@ export function findAllRoutes<T>(
     path = path.slice(0, -1);
   }
   const segments = splitPath(path);
-  const _matches = _findAll(ctx, ctx.root, method, segments, 0);
-  const matches: MatchedRoute<T>[] = [];
-  for (const match of _matches) {
-    matches.push({
-      data: match.data,
-      params:
-        match.paramsMap && opts?.params !== false
-          ? getMatchParams(segments, match.paramsMap)
-          : undefined,
-    });
+  const matches = _findAll(ctx, ctx.root, method, segments, 0);
+
+  if (opts?.params === false) {
+    return matches;
   }
-  return matches;
+
+  return matches.map((m) => {
+    return {
+      data: m.data,
+      params: m.paramsMap ? getMatchParams(segments, m.paramsMap) : undefined,
+    };
+  });
 }
 
 function _findAll<T>(

--- a/src/operations/find-all.ts
+++ b/src/operations/find-all.ts
@@ -42,7 +42,7 @@ function _findAll<T>(
   if (node.wildcard && node.wildcard.methods) {
     const match = node.wildcard.methods[method] || node.wildcard.methods[""];
     if (match) {
-      matches.push(match);
+      matches.push(...match);
     }
   }
 
@@ -52,7 +52,7 @@ function _findAll<T>(
     if (index === segments.length && node.param.methods) {
       const match = node.param.methods[method] || node.param.methods[""];
       if (match) {
-        matches.push(match);
+        matches.push(...match);
       }
     }
   }
@@ -67,7 +67,7 @@ function _findAll<T>(
   if (index === segments.length && node.methods) {
     const match = node.methods[method] || node.methods[""];
     if (match) {
-      matches.push(match);
+      matches.push(...match);
     }
   }
 

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -32,19 +32,6 @@ export function findRoute<T = unknown>(
     return;
   }
 
-  if (match.length === 1) {
-    const m = match[0];
-    return [
-      {
-        data: m.data,
-        params:
-          m.paramsMap && opts?.params !== false
-            ? getMatchParams(segments, m.paramsMap)
-            : undefined,
-      },
-    ];
-  }
-
   const _matches = [];
   for (const m of match) {
     _matches.push({

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -32,18 +32,15 @@ export function findRoute<T = unknown>(
     return;
   }
 
-  const _matches = [];
-  for (const m of match) {
-    _matches.push({
+  return match.map((m) => {
+    return {
       data: m.data,
       params:
         m.paramsMap && opts?.params !== false
           ? getMatchParams(segments, m.paramsMap)
           : undefined,
-    });
-  }
-
-  return _matches;
+    };
+  });
 }
 
 function _lookupTree<T>(

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -26,19 +26,20 @@ export function findRoute<T = unknown>(
   // Lookup tree
   const segments = splitPath(path);
 
-  const match = _lookupTree<T>(ctx, ctx.root, method, segments, 0);
+  const matches = _lookupTree<T>(ctx, ctx.root, method, segments, 0);
 
-  if (match === undefined) {
+  if (matches === undefined) {
     return;
   }
 
-  return match.map((m) => {
+  if (opts?.params === false) {
+    return matches;
+  }
+
+  return matches.map((m) => {
     return {
       data: m.data,
-      params:
-        m.paramsMap && opts?.params !== false
-          ? getMatchParams(segments, m.paramsMap)
-          : undefined,
+      params: m.paramsMap ? getMatchParams(segments, m.paramsMap) : undefined,
     };
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,8 +13,7 @@ export interface Node<T = unknown> {
   param?: Node<T>;
   wildcard?: Node<T>;
 
-  index?: number;
-  methods?: Record<string, MethodData<T> | undefined>;
+  methods?: Record<string, MethodData<T>[] | undefined>;
 }
 
 export type MatchedRoute<T = unknown> = {

--- a/test/_utils.ts
+++ b/test/_utils.ts
@@ -52,8 +52,10 @@ function _formatMethods(node: Node<{ path?: string }>) {
     return "";
   }
   return ` ┈> ${Object.entries(node.methods)
-    .map(([method, d]) => {
-      const val = d?.data?.path || JSON.stringify(d?.data);
+    .map(([method, arr]) => {
+      const val =
+        arr?.map((d) => d?.data?.path || JSON.stringify(d?.data)).join(" + ") ||
+        "";
       return `[${method || "*"}] ${val}`;
     })
     .join(", ")}`;

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { createRouter, formatTree } from "./_utils";
-import { findRoute, removeRoute } from "../src";
+import { findRoute as _findRoute, removeRoute } from "../src";
+
+const findRoute = (router: any, method: string, path: string) =>
+  _findRoute(router, method, path)?.[0];
 
 describe("Basic router", () => {
   const router = createRouter([

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -14,7 +14,7 @@ describe("benchmark", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log("bundle size", { bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(2500); // <2.5kb
+    expect(bytes).toBeLessThanOrEqual(2600); // <2.6kb
     expect(gzipSize).toBeLessThanOrEqual(1000); // <1kb
   });
 });

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -14,7 +14,7 @@ describe("benchmark", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     // console.log("bundle size", { bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(2600); // <2.6kb
+    expect(bytes).toBeLessThanOrEqual(2500); // <2.5kb
     expect(gzipSize).toBeLessThanOrEqual(1000); // <1kb
   });
 });

--- a/test/bench/impl.ts
+++ b/test/bench/impl.ts
@@ -33,7 +33,8 @@ export function createRouter(rou3: typeof rou3Src, withAll: boolean = false) {
     };
   }
   return (method: string, path: string) => {
-    return rou3.findRoute(router, method, path);
+    const r = rou3.findRoute(router, method, path);
+    return r?.[0] || r;
   };
 }
 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,7 +1,10 @@
 import type { RouterContext } from "../src/types";
 import { describe, it, expect } from "vitest";
 import { createRouter, formatTree } from "./_utils";
-import { addRoute, findRoute, removeRoute } from "../src";
+import { addRoute, findRoute as _findRoute, removeRoute } from "../src";
+
+const findRoute = (router: any, method: string, path: string) =>
+  _findRoute(router, method, path)?.[0];
 
 type TestRoute = {
   data: { path: string };
@@ -374,7 +377,6 @@ describe("Router insert", () => {
       "hi",
       "helium",
       "/choo",
-      "//choo",
       "coooool",
       "chrome",
       "choot",
@@ -396,7 +398,7 @@ describe("Router insert", () => {
           ├── /cool ┈> [GET] cool
           ├── /hi ┈> [GET] hi
           ├── /helium ┈> [GET] helium
-          ├── /choo ┈> [GET] //choo
+          ├── /choo ┈> [GET] /choo
           ├── /coooool ┈> [GET] coooool
           ├── /chrome ┈> [GET] chrome
           ├── /choot ┈> [GET] choot


### PR DESCRIPTION
Resolves #57

(context: workerd on it as part of h3 refactors to use rou3 as middleware matcher)

Previously we were only supporting one handler for each route (`/foo/:bar` and `/foo/*` are the same).

This change changes the store to an array and return type of `find` to an array.

## perf

overhead is < %5

<img width="824" alt="image" src="https://github.com/unjs/rou3/assets/5158436/e0d5281b-1614-4f87-b212-cfd2bf2b3ee9">