### PR TITLE
perf!(findRoute): return first result

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ addRoute(router, "GET", "/path/foo/**:name", {
 **Match route to access matched data:**
 
 ```js
-// Returns [{ payload: 'this path' }]
+// Returns { payload: 'this path' }
 findRoute(router, "GET", "/path");
 
-// Returns [{ payload: 'named route', params: { name: 'fooval' } }]
+// Returns { payload: 'named route', params: { name: 'fooval' } }
 findRoute(router, "POST", "/path/fooval");
 
-// Returns [{ payload: 'wildcard route' }]
+// Returns { payload: 'wildcard route' }
 findRoute(router, "GET", "/path/foo/bar/baz");
 
 // Returns undefined (no route matched for/)

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -9,7 +9,7 @@ export function findRoute<T = unknown>(
   method: string = "",
   path: string,
   opts?: { params?: boolean },
-): MatchedRoute<T>[] | undefined {
+): MatchedRoute<T> | undefined {
   if (path[path.length - 1] === "/") {
     path = path.slice(0, -1);
   }
@@ -19,29 +19,29 @@ export function findRoute<T = unknown>(
   if (staticNode && staticNode.methods) {
     const staticMatch = staticNode.methods[method] || staticNode.methods[""];
     if (staticMatch !== undefined) {
-      return staticMatch;
+      return staticMatch[0];
     }
   }
 
   // Lookup tree
   const segments = splitPath(path);
 
-  const matches = _lookupTree<T>(ctx, ctx.root, method, segments, 0);
+  const match = _lookupTree<T>(ctx, ctx.root, method, segments, 0)?.[0];
 
-  if (matches === undefined) {
+  if (match === undefined) {
     return;
   }
 
   if (opts?.params === false) {
-    return matches;
+    return match;
   }
 
-  return matches.map((m) => {
-    return {
-      data: m.data,
-      params: m.paramsMap ? getMatchParams(segments, m.paramsMap) : undefined,
-    };
-  });
+  return {
+    data: match.data,
+    params: match.paramsMap
+      ? getMatchParams(segments, match.paramsMap)
+      : undefined,
+  };
 }
 
 function _lookupTree<T>(

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { createRouter, formatTree } from "./_utils";
-import { findRoute as _findRoute, removeRoute } from "../src";
-
-const findRoute = (router: any, method: string, path: string) =>
-  _findRoute(router, method, path)?.[0];
+import { findRoute, removeRoute } from "../src";
 
 describe("Basic router", () => {
   const router = createRouter([

--- a/test/bench/impl.ts
+++ b/test/bench/impl.ts
@@ -1,16 +1,16 @@
 import * as rou3Src from "../../src";
-import * as rou3Release from "rou3-release";
+// import * as rou3Release from "rou3-release";
 import { requests, routes } from "./input";
 
 export function createInstances() {
   return [
-    ["rou3-src", createRouter(rou3Src)],
-    ["rou3-src-find-all", createRouter(rou3Src, true)],
-    ["rou3-release", createRouter(rou3Release as unknown as typeof rou3Src)],
-    [
-      "rou3-release-find-all",
-      createRouter(rou3Release as unknown as typeof rou3Src, true),
-    ],
+    ["rou3", createRouter(rou3Src)],
+    ["rou3-find-all", createRouter(rou3Src, true)],
+    // ["rou3-release", createRouter(rou3Release as unknown as typeof rou3Src)],
+    // [
+    //   "rou3-release-find-all",
+    //   createRouter(rou3Release as unknown as typeof rou3Src, true),
+    // ],
     process.argv.includes("--max")
       ? ["maximum", createFastestRouter()]
       : undefined,
@@ -33,8 +33,7 @@ export function createRouter(rou3: typeof rou3Src, withAll: boolean = false) {
     };
   }
   return (method: string, path: string) => {
-    const r = rou3.findRoute(router, method, path);
-    return r?.[0] || r;
+    return rou3.findRoute(router, method, path);
   };
 }
 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,10 +1,7 @@
 import type { RouterContext } from "../src/types";
 import { describe, it, expect } from "vitest";
 import { createRouter, formatTree } from "./_utils";
-import { addRoute, findRoute as _findRoute, removeRoute } from "../src";
-
-const findRoute = (router: any, method: string, path: string) =>
-  _findRoute(router, method, path)?.[0];
+import { addRoute, findRoute, removeRoute } from "../src";
 
 type TestRoute = {
   data: { path: string };


### PR DESCRIPTION
Internally we store an array of matches because with `matchAll`, it is possible to match `/foo/:bar` + `/foo/:baz` (same method) but for purpose of routing only one route is meaningful to be matchable.

This PR increases perf by %12-17 by avoiding array creation (and also honestly, the DX)