### PR TITLE
fix!: last named segment should be required

### DIFF
--- a/src/operations/add.ts
+++ b/src/operations/add.ts
@@ -39,7 +39,11 @@ export function addRoute<T>(
         node.wildcard = { key: "**" };
       }
       node = node.wildcard;
-      paramsMap.push([-i, segment.split(":")[1] || "_"]);
+      paramsMap.push([
+        -i,
+        segment.split(":")[1] || "_",
+        segment.length === 2 /* no id */,
+      ]);
       break;
     }
 
@@ -49,11 +53,13 @@ export function addRoute<T>(
         node.param = { key: "*" };
       }
       node = node.param;
+      const isOptional = segment === "*";
       paramsMap.push([
         i,
-        segment === "*"
+        isOptional
           ? `_${_unnamedParamIndex++}`
           : (_getParamMatcher(segment) as string),
+        isOptional,
       ]);
       continue;
     }

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -63,15 +63,20 @@ function _lookupTree<T>(
     if (node.param && node.param.methods) {
       const match = node.param.methods[method] || node.param.methods[""];
       if (match) {
-        const map = match[0].paramsMap;
-        const isLastPartOptional = map?.[map?.length - 1]?.[2];
-        if (isLastPartOptional) {
+        const pMap = match[0].paramsMap;
+        if (pMap?.[pMap?.length - 1]?.[2] /* optional */) {
           return match;
         }
       }
     }
     if (node.wildcard && node.wildcard.methods) {
-      return node.wildcard.methods[method] || node.wildcard.methods[""];
+      const match = node.wildcard.methods[method] || node.wildcard.methods[""];
+      if (match) {
+        const pMap = match[0].paramsMap;
+        if (pMap?.[pMap?.length - 1]?.[2] /* optional */) {
+          return match;
+        }
+      }
     }
     return undefined;
   }

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -63,7 +63,11 @@ function _lookupTree<T>(
     if (node.param && node.param.methods) {
       const match = node.param.methods[method] || node.param.methods[""];
       if (match) {
-        return match;
+        const map = match[0].paramsMap;
+        const isLastPartOptional = map?.[map?.length - 1]?.[2];
+        if (isLastPartOptional) {
+          return match;
+        }
       }
     }
     if (node.wildcard && node.wildcard.methods) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,9 @@ export interface RouterContext<T = unknown> {
   static: Record<string, Node<T> | undefined>;
 }
 
-export type ParamsIndexMap = Array<[Index: number, name: string | RegExp]>;
+export type ParamsIndexMap = Array<
+  [Index: number, name: string | RegExp, optional: boolean]
+>;
 export type MethodData<T = unknown> = { data: T; paramsMap?: ParamsIndexMap };
 
 export interface Node<T = unknown> {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -78,6 +78,7 @@ describe("Router lookup", function () {
   describe("retrieve placeholders", function () {
     testRouter(
       [
+        "blog/*",
         "carbon/:element",
         "carbon/:element/test/:testing",
         "this/:route/has/:cool/stuff",
@@ -85,6 +86,8 @@ describe("Router lookup", function () {
       (router) =>
         expect(formatTree(router.root)).toMatchInlineSnapshot(`
           "<root>
+              ├── /blog
+              │       ├── /* ┈> [GET] blog/*
               ├── /carbon
               │       ├── /* ┈> [GET] carbon/:element
               │       │       ├── /test
@@ -102,8 +105,8 @@ describe("Router lookup", function () {
             element: "test1",
           },
         },
-        "/carbon": { data: { path: "carbon/:element" } },
-        "carbon/": { data: { path: "carbon/:element" } },
+        "/carbon": undefined,
+        "carbon/": undefined,
         "carbon/test2/test/test23": {
           data: { path: "carbon/:element/test/:testing" },
           params: {
@@ -118,6 +121,9 @@ describe("Router lookup", function () {
             cool: "more",
           },
         },
+        "/blog": { data: { path: "blog/*" } },
+        "blog/": { data: { path: "blog/*" } },
+        "blog/123": { data: { path: "blog/*" } },
       },
     );
 
@@ -330,6 +336,7 @@ describe("Router lookup", function () {
           data: { path: mixedPath },
           params: { category: "test", id: "123", name: "foobar" },
         },
+        "/files/test": undefined,
       },
     );
   });
@@ -428,10 +435,7 @@ describe("Router remove", function () {
     ]);
 
     removeRoute(router, "GET", "choot");
-    expect(findRoute(router, "GET", "choot")).to.deep.equal({
-      data: { path: "choot/:choo" },
-      params: { choo: undefined },
-    });
+    expect(findRoute(router, "GET", "choot")).to.deep.equal(undefined);
     removeRoute(router, "GET", "choot/*");
     expect(findRoute(router, "GET", "choot")).to.deep.equal(undefined);
 
@@ -448,16 +452,16 @@ describe("Router remove", function () {
   });
 
   it("removes data but does not delete a node if it has children", function () {
-    const router = createRouter(["a/b", "a/b/:param1"]);
+    const router = createRouter(["a/b", "a/b/*"]);
 
     removeRoute(router, "GET", "a/b");
     expect(findRoute(router, "GET", "a/b")).to.deep.equal({
-      data: { path: "a/b/:param1" },
-      params: { param1: undefined },
+      data: { path: "a/b/*" },
+      params: { _0: undefined },
     });
     expect(findRoute(router, "GET", "a/b/c")).to.deep.equal({
-      params: { param1: "c" },
-      data: { path: "a/b/:param1" },
+      params: { _0: "c" },
+      data: { path: "a/b/*" },
     });
     removeRoute(router, "GET", "a/b/*");
     expect(findRoute(router, "GET", "a/b")).to.deep.equal(undefined);


### PR DESCRIPTION
resolves #119 and related comment in https://github.com/unjs/rou3/issues/84#issuecomment-2226854050

I made a [twitter survey](https://twitter.com/_pi0_/status/1813329869968928827) and it seems most of people expect `/blog/*` to also match `/blog` but as another fair point, `/blog/:id` should not match `/blog` by default because we are expecting a named parameter.

This PR does a middleground solution to only do edge matching for optional last segments (`*` and `**`)