### PR TITLE
Update router.ts [radix3] [resolves #148]

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -69,6 +69,8 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
         node =
           node.placeholderChildren.find((c) => c.maxDepth === remaining) ||
           null;
+          if(node && node.paramPrefix && section.startsWith(node.paramPrefix) == false)
+					  node = null;
       } else {
         node = node.placeholderChildren[0] || null;
       }
@@ -76,7 +78,8 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
         break;
       }
       if (node.paramName) {
-        params[node.paramName] = node.paramOffset ? section.slice(node.paramOffset) : section;
+        params[node.paramName] = 
+          node.paramPrefix ? section.slice(node.paramPrefix.length) : section;
       }
       paramsFound = true;
     } else {
@@ -133,8 +136,10 @@ function insert(ctx: RadixRouterContext, path: string, data: any) {
           childNode.paramName = `_${_unnamedPlaceholderCtr++}`
 				else
 				{
-					childNode.paramOffset = section.indexOf(':'); //allow parameter to have a prefix "path/prefix-:name"
-					childNode.paramName = section.slice(childNode.paramOffset + 1);
+          //allow parameter to have a prefix "path/prefix-:name"
+					let ix = section.indexOf(':');
+          childNode.paramPrefix = section.slice(0, ix); 
+					childNode.paramName = section.slice(ix+1);
 				}
         node.placeholderChildren.push(childNode);
         isStaticRoute = false;
@@ -199,7 +204,7 @@ function createRadixNode(options: Partial<RadixNode> = {}): RadixNode {
     children: new Map(),
     data: options.data || null,
     paramName: options.paramName || null,
-		paramOffset: 0,
+		paramPrefix: null,
     wildcardChildNode: null,
     placeholderChildren: [],
   };

--- a/src/router.ts
+++ b/src/router.ts
@@ -67,12 +67,16 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
         // https://github.com/unjs/radix3/issues/95
         const remaining = sections.length - i;
         node =
-          node.placeholderChildren.find((c) => c.maxDepth === remaining) ||
-          null;
+          node.placeholderChildren.find((c) => {
+            let ok = c.maxDepth === remaining;
+            if(ok && c.paramPrefix)
+              ok = section.startsWith(c.paramPrefix);
+            return ok;
+          }) || null;
       } else {
         node = node.placeholderChildren[0] || null;
         if(node && node.paramPrefix && section.startsWith(node.paramPrefix) == false)
-	  node = null;
+          node = null;
       }
       if (!node) {
         break;

--- a/src/router.ts
+++ b/src/router.ts
@@ -69,10 +69,10 @@ function lookup<T extends RadixNodeData = RadixNodeData>(
         node =
           node.placeholderChildren.find((c) => c.maxDepth === remaining) ||
           null;
-          if(node && node.paramPrefix && section.startsWith(node.paramPrefix) == false)
-					  node = null;
       } else {
         node = node.placeholderChildren[0] || null;
+        if(node && node.paramPrefix && section.startsWith(node.paramPrefix) == false)
+	  node = null;
       }
       if (!node) {
         break;
@@ -134,13 +134,13 @@ function insert(ctx: RadixRouterContext, path: string, data: any) {
       if (type === NODE_TYPES.PLACEHOLDER) {
         if(section === "*")
           childNode.paramName = `_${_unnamedPlaceholderCtr++}`
-				else
-				{
+	else
+	{
           //allow parameter to have a prefix "path/prefix-:name"
-					let ix = section.indexOf(':');
+	  let ix = section.indexOf(':');
           childNode.paramPrefix = section.slice(0, ix); 
-					childNode.paramName = section.slice(ix+1);
-				}
+	  childNode.paramName = section.slice(ix + 1);
+	}
         node.placeholderChildren.push(childNode);
         isStaticRoute = false;
       } else if (type === NODE_TYPES.WILDCARD) {
@@ -204,7 +204,7 @@ function createRadixNode(options: Partial<RadixNode> = {}): RadixNode {
     children: new Map(),
     data: options.data || null,
     paramName: options.paramName || null,
-		paramPrefix: null,
+    paramPrefix: null,
     wildcardChildNode: null,
     placeholderChildren: [],
   };


### PR DESCRIPTION
allow parameters to have a prefix "/path/prefix-:name" e.g. 
/api/load/cat-:id will match /api/load/cat-123    with id == '123'
/api/load/toy-:type will match /api/load/toy-train   with type == 'train'

currently parameter has to be in the beginning of the string '/path/:param', otherwise the route never matches.

I'm working with Nuxt which has Nitro which uses radix3 and I have to make API Routes like 
/api/cat/[id].ts
/api/toy/[id].ts
which makes both files have the same name '[id].ts' and is confusing.

With this modification I would be able to use
/api/load/cat-[id].ts
/api/load/toy-[id].ts


import { createRouter } from "radix3";
const router = createRouter(/* options */);
router.insert("/path/foo/cat-:name", { payload: "named route"});
console.log( router.lookup("/path/foo/cat-test123") );
//returns undefined 
//and after fix: { payload: 'named route', params: { name: 'test123' } }